### PR TITLE
Updated RDO repo and epel

### DIFF
--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -136,7 +136,6 @@ class openstack_extras::repo::redhat::redhat(
     if ($::osfamily == 'RedHat' and
         $::operatingsystem != 'Fedora')
     {
-      notify { "epel code ran": }
       # 'metalink' property is supported from Puppet 3.5
       if (versioncmp($::puppetversion, '3.5') >= 0) {
         $epel_hash = { 'epel' => {

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -136,13 +136,14 @@ class openstack_extras::repo::redhat::redhat(
     if ($::osfamily == 'RedHat' and
         $::operatingsystem != 'Fedora')
     {
+      notify { "epel code ran": }
       # 'metalink' property is supported from Puppet 3.5
       if (versioncmp($::puppetversion, '3.5') >= 0) {
         $epel_hash = { 'epel' => {
             'metalink'        => "https://mirrors.fedoraproject.org/metalink?repo=epel-${::operatingsystemmajrelease}&arch=\$basearch",
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-            'failovermethod'  => 'priority'
+            'failovermethod'  => 'priority',
             'exclude'         => 'zeromq'
           }
         }
@@ -151,7 +152,7 @@ class openstack_extras::repo::redhat::redhat(
             'baseurl'         => "https://download.fedoraproject.org/pub/epel/${::operatingsystemmajrelease}/\$basearch",
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
-            'failovermethod'  => 'priority'
+            'failovermethod'  => 'priority',
             'exclude'         => 'zeromq'
           }
         }

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -76,7 +76,7 @@ class openstack_extras::repo::redhat::redhat(
   $purge_unmanaged   = false,
   $package_require   = false,
   $manage_priorities = true,
-  $centos_mirror_url = 'http://mirror.centos.org',
+  $centos_mirror_url = 'http://vault.centos.org',
 ) inherits openstack_extras::repo::redhat::params {
 
   validate_string($release)

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -99,7 +99,7 @@ class openstack_extras::repo::redhat::redhat(
 
     $rdo_hash = {
       'rdo-release' => {
-        'baseurl'  => "http://vault.centos.org/7.4.1708/cloud/x86_64/openstack-newton/",
+        'baseurl'  => "http://vault.centos.org/7.4.1708/cloud/\$basearch/openstack-${release}/",
         'descr'    => "OpenStack ${release_cap} Repository",
         'gpgkey'   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud',
       }

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -68,7 +68,7 @@ class openstack_extras::repo::redhat::redhat(
   $release           = $::openstack_extras::repo::redhat::params::release,
   $manage_rdo        = true,
   $manage_virt       = true,
-  $manage_epel       = false,
+  $manage_epel       = true,
   $repo_hash         = {},
   $repo_defaults     = {},
   $gpgkey_hash       = {},

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -76,7 +76,7 @@ class openstack_extras::repo::redhat::redhat(
   $purge_unmanaged   = false,
   $package_require   = false,
   $manage_priorities = true,
-  $centos_mirror_url = 'http://vault.centos.org',
+  $centos_mirror_url = 'http://mirror.centos.org',
 ) inherits openstack_extras::repo::redhat::params {
 
   validate_string($release)

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -143,6 +143,7 @@ class openstack_extras::repo::redhat::redhat(
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
             'failovermethod'  => 'priority'
+            'exclude'         => 'zeromq'
           }
         }
       } else {
@@ -151,6 +152,7 @@ class openstack_extras::repo::redhat::redhat(
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
             'failovermethod'  => 'priority'
+            'exclude'         => 'zeromq'
           }
         }
       }

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -99,7 +99,7 @@ class openstack_extras::repo::redhat::redhat(
 
     $rdo_hash = {
       'rdo-release' => {
-        'baseurl'  => "${centos_mirror_url}/centos/7.4.1708/cloud/\$basearch/openstack-${release}/",
+        'baseurl'  => "http://vault.centos.org/7.4.1708/cloud/x86_64/openstack-newton/",
         'descr'    => "OpenStack ${release_cap} Repository",
         'gpgkey'   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud',
       }

--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -99,7 +99,7 @@ class openstack_extras::repo::redhat::redhat(
 
     $rdo_hash = {
       'rdo-release' => {
-        'baseurl'  => "http://vault.centos.org/7.4.1708/cloud/x86_64/openstack-newton/",
+        'baseurl'  => "${centos_mirror_url}/centos/7.4.1708/cloud/\$basearch/openstack-${release}/",
         'descr'    => "OpenStack ${release_cap} Repository",
         'gpgkey'   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud',
       }


### PR DESCRIPTION
Newton is not supported in CenOS 7.5.
- The RDO repo got archived and is now hosted in vault.centos.org
- The epel repo has not been manage for the frontend nodes by 
Puppet until now. We need to manage it since we need to exclude
zeromq so it does not conflict with RDO. Previously the repo was 
only added by the kickstart.
CCCP-2107