### PR TITLE
Extend EPEL exclude to python2-zmq

### DIFF
--- a/manifests/repo/redhat/redhat.pp
+++ b/manifests/repo/redhat/redhat.pp
@@ -143,7 +143,7 @@ class openstack_extras::repo::redhat::redhat(
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
             'failovermethod'  => 'priority',
-            'exclude'         => 'zeromq'
+            'exclude'         => 'zeromq,python2-zmq'
           }
         }
       } else {
@@ -152,7 +152,7 @@ class openstack_extras::repo::redhat::redhat(
             'descr'           => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
             'gpgkey'          => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::operatingsystemmajrelease}",
             'failovermethod'  => 'priority',
-            'exclude'         => 'zeromq'
+            'exclude'         => 'zeromq,python2-zmq'
           }
         }
       }


### PR DESCRIPTION
Which fixes some neutron dependency clashes with RDO <-> EPEL in API nodes.